### PR TITLE
Fix export parsing and completions path

### DIFF
--- a/server/symbolIndex.ts
+++ b/server/symbolIndex.ts
@@ -6,7 +6,9 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { pathToFileURL } from 'url';
 
-const completionsPath = path.resolve(__dirname, '../shared/completions.json');
+// __dirname points to "server/server-dist/server" after compilation
+// so go three levels up to reach repo root and the shared folder
+const completionsPath = path.resolve(__dirname, '../../../shared/completions.json');
 const builtinCompletions = JSON.parse(fs.readFileSync(completionsPath, 'utf8'));
 
 import { connection } from './server'; // you'll need to export this

--- a/shared/parser.ts
+++ b/shared/parser.ts
@@ -29,9 +29,18 @@ export function parseAST(text: string): { ast: ASTNode[]; includes: string[] } {
         const t = tokens[i];
         const tokenVal = t.value.toUpperCase();
         const isLineStart = i === 0 || tokens[i - 1].value.includes('\n');
+
         // === Function funcName(...) BEGIN ===
-        if (isLineStart && t.type === TokenType.Identifier && /^[A-Za-z]/.test(t.value)) {
-            let parenIdx = i + 1;
+        let nameIdx = i;
+        if (isLineStart && t.type === TokenType.Keyword && (tokenVal === 'EXPORT' || tokenVal === 'LOCAL')) {
+            nameIdx = i + 1;
+            while (tokens[nameIdx] && (tokens[nameIdx].type === TokenType.Whitespace || tokens[nameIdx].type === TokenType.Comment)) {
+                nameIdx++;
+            }
+        }
+        const nameTok = tokens[nameIdx];
+        if (isLineStart && nameTok && nameTok.type === TokenType.Identifier && /^[A-Za-z]/.test(nameTok.value)) {
+            let parenIdx = nameIdx + 1;
 
             // Skip intervening non-symbols until we find the '('
             while (
@@ -113,9 +122,9 @@ export function parseAST(text: string): { ast: ASTNode[]; includes: string[] } {
 
             const func: FunctionNode = {
                 type: 'Function',
-                name: t.value,
+                name: nameTok.value,
                 params,
-                start: { offset: t.offset },
+                start: { offset: nameTok.offset },
                 end: null,
                 body: {
                     type: 'Block',


### PR DESCRIPTION
## Summary
- handle EXPORT or LOCAL keywords before function name
- correct completions.json lookup path in server

## Testing
- `npm run build`
- `node -e "const parse=require('./client/out/shared/parser.js').parseAST; console.log(JSON.stringify(parse('EXPORT foo()\nBEGIN\nRETURN 42;\nEND;'), null, 2));"`
- `node - <<'NODE'
const {updateSymbolsForDocument,findSymbol}=require('./server/server-dist/server/symbolIndex.js');
const {TextDocument}=require('vscode-languageserver-textdocument');
const fs=require('fs');
const text=fs.readFileSync('/tmp/test.hpprgm','utf8');
const doc=TextDocument.create('file:///tmp/test.hpprgm','hpprime',1,text);
updateSymbolsForDocument(doc);
console.log(findSymbol('foo'));
NODE

------
https://chatgpt.com/codex/tasks/task_e_684f70f9008c8324a35c154fcfa05150