### PR TITLE
Restore build script for HP PPL bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,36 @@ To install this extension, follow these steps:
 
 After installing the extension, you can start writing HP Prime Programming Language (HP PPL) code in VSCode by opening a `.hpprgm` file or creating a new one. The extension will automatically activate, providing syntax highlighting and auto-completion for HP PPL code.
 
+### Building a Combined Program
+
+A simple build script is included to merge a project with `#include` dependencies into a single `combined.hpprgm` file. Run the following from your project folder:
+
+```bash
+npm run bundle <entry-file.hpprgm> [output.hpprgm]
+```
+
+The script resolves `#include` directives, orders files by function dependencies, and writes the result to `combined.hpprgm` (or the output path you provide).
+
+You can also wire the bundler to VSCode's **Run Build Task** command by creating a `tasks.json` with an `hpprime` task:
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "HP Prime: Build",
+      "type": "hpprime",
+      "entry": "src/main.hpprgm",
+      "output": "combined.hpprgm",
+      "group": "build",
+      "problemMatcher": []
+    }
+  ]
+}
+```
+
+Press `Ctrl+Shift+B` to run the task and produce the combined program.
+
 ### Acknowledgements
 - The original work for **HP Prime Programming Language** support in Notepad++ was written by **Juerg W. Buser** and **Terje Vallestad**. Their contributions made this extension possible.
 - This extension was developed by **Seamoose04** to provide the HP Prime community with enhanced support in VSCode.

--- a/client/package.json
+++ b/client/package.json
@@ -38,6 +38,23 @@
                 "command": "hpprime.buildCombinedFile",
                 "title": "HP Prime: Build Combined File"
             }
+        ],
+        "taskDefinitions": [
+            {
+                "type": "hpprime",
+                "required": ["entry"],
+                "properties": {
+                    "entry": {
+                        "type": "string",
+                        "description": "Entry HP PPL file"
+                    },
+                    "output": {
+                        "type": "string",
+                        "description": "Output file",
+                        "default": "combined.hpprgm"
+                    }
+                }
+            }
         ]
     },
     "scripts": {
@@ -53,7 +70,8 @@
         "out/",
         "syntaxes/",
         "language-configuration.json",
-        "../server-dist/"
+        "../server-dist/",
+        "../scripts/"
     ],
     "author": "",
     "license": "ISC",

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { buildHPProgram } from './build';
+import { HPPrimeTaskProvider } from './taskProvider';
 import {
     LanguageClient,
     LanguageClientOptions,
@@ -29,6 +30,12 @@ export function activate(context: vscode.ExtensionContext) {
         serverOptions,
         clientOptions
     );
+
+    const provider = vscode.tasks.registerTaskProvider(
+        HPPrimeTaskProvider.type,
+        new HPPrimeTaskProvider(context)
+    );
+    context.subscriptions.push(provider);
 
     context.subscriptions.push(vscode.commands.registerCommand('hpprime.buildCombinedFile', async () => {
         const entryUri = await vscode.window.showOpenDialog({

--- a/client/src/taskProvider.ts
+++ b/client/src/taskProvider.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export interface HPPrimeTaskDefinition extends vscode.TaskDefinition {
+    /** Entry HP PPL file */
+    entry: string;
+    /** Optional output path */
+    output?: string;
+}
+
+export class HPPrimeTaskProvider implements vscode.TaskProvider {
+    static readonly type = 'hpprime';
+    constructor(private context: vscode.ExtensionContext) {}
+
+    provideTasks(): vscode.ProviderResult<vscode.Task[]> {
+        // Tasks are resolved on demand; none provided by default
+        return [];
+    }
+
+    resolveTask(task: vscode.Task): vscode.ProviderResult<vscode.Task> {
+        const definition = task.definition as HPPrimeTaskDefinition;
+        if (!definition.entry) {
+            return undefined;
+        }
+
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            return undefined;
+        }
+
+        const script = this.context.asAbsolutePath(path.join('..', 'scripts', 'build.js'));
+        const args = [definition.entry];
+        if (definition.output) {
+            args.push(definition.output);
+        }
+        const quotedArgs = args.map(a => `"${a}"`).join(' ');
+        const exec = new vscode.ShellExecution(`node "${script}" ${quotedArgs}`);
+        const resolved = new vscode.Task(
+            definition,
+            workspaceFolder,
+            task.name,
+            'hpprime',
+            exec
+        );
+        resolved.group = vscode.TaskGroup.Build;
+        return resolved;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "vscode-languageclient": "^9.0.1"
   },
   "scripts": {
-      "build": "npm run build-client && npm run build-server",
-      "build-client": "tsc -p client/tsconfig.json",
-      "build-server": "tsc -p server/tsconfig.json",
-      "watch": "tsc --watch"
+    "build": "npm run build-client && npm run build-server",
+    "build-client": "tsc -p client/tsconfig.json",
+    "build-server": "tsc -p server/tsconfig.json",
+    "watch": "tsc --watch",
+    "bundle": "node scripts/build.js"
   },
   "repository": {
     "type": "git",
@@ -34,16 +35,25 @@
   ],
   "main": "./client/out/client/src/extension.js",
   "contributes": {
-    "languages": [{
-      "id": "hpprime",
-      "aliases": ["HPPRIME", "hpprime"],
-      "extensions": [".hpprime"]
-    }],
-    "grammars": [{
-      "language": "hpprime",
-      "scopeName": "source.hpprime",
-      "path": "./client/syntaxes/hpprime.tmLanguage.json"
-    }],
+    "languages": [
+      {
+        "id": "hpprime",
+        "aliases": [
+          "HPPRIME",
+          "hpprime"
+        ],
+        "extensions": [
+          ".hpprime"
+        ]
+      }
+    ],
+    "grammars": [
+      {
+        "language": "hpprime",
+        "scopeName": "source.hpprime",
+        "path": "./client/syntaxes/hpprime.tmLanguage.json"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "HPPRIME Language Support",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const FUNC_DEF_RE = /^\s*(\w+)\s*\([^)]*\)\s*\n\s*BEGIN\b/gim;
+const FUNC_CALL_RE = /\b(\w+)\s*\(/g;
+const INCLUDE_RE = /#include\s+"(.+?)"/g;
+
+function parseFile(filePath) {
+    const text = fs.readFileSync(filePath, 'utf8');
+    const includes = [];
+    for (const m of text.matchAll(INCLUDE_RE)) includes.push(m[1]);
+    const defs = new Set();
+    for (const m of text.matchAll(FUNC_DEF_RE)) defs.add(m[1]);
+    const calls = new Set();
+    for (const m of text.matchAll(FUNC_CALL_RE)) {
+        if (!defs.has(m[1])) calls.add(m[1]);
+    }
+    return { text, includes, defs, calls };
+}
+
+function resolveIncludes(entry, seen) {
+    const blocks = [];
+    if (seen.has(entry) || !fs.existsSync(entry)) return blocks;
+    seen.add(entry);
+    const { text, includes } = parseFile(entry);
+    for (const inc of includes) {
+        const resolved = path.resolve(path.dirname(entry), inc);
+        blocks.push(...resolveIncludes(resolved, seen));
+    }
+    blocks.push({ path: entry, text });
+    return blocks;
+}
+
+function buildDependencyGraph(files) {
+    const defines = new Map();
+    const callsInFile = new Map();
+    for (const { path: p, text } of files) {
+        const { defs, calls } = parseFile(p);
+        callsInFile.set(p, calls);
+        for (const d of defs) defines.set(d, p);
+    }
+    const graph = new Map();
+    for (const { path: p } of files) {
+        const calls = callsInFile.get(p) || new Set();
+        for (const c of calls) {
+            const dep = defines.get(c);
+            if (dep && dep !== p) {
+                if (!graph.has(p)) graph.set(p, new Set());
+                graph.get(p).add(dep);
+            }
+        }
+    }
+    return graph;
+}
+
+function topoSort(files, graph) {
+    const indegree = new Map();
+    for (const { path: p } of files) indegree.set(p, 0);
+    for (const deps of graph.values()) {
+        for (const dep of deps) indegree.set(dep, (indegree.get(dep) || 0) + 1);
+    }
+    const queue = files.filter(f => indegree.get(f.path) === 0).map(f => f.path);
+    const ordered = [];
+    while (queue.length) {
+        const p = queue.shift();
+        const file = files.find(f => f.path === p);
+        ordered.push(file);
+        for (const neigh of graph.get(p) || []) {
+            indegree.set(neigh, indegree.get(neigh) - 1);
+            if (indegree.get(neigh) === 0) queue.push(neigh);
+        }
+    }
+    if (ordered.length !== files.length) throw new Error('Cyclic dependency detected');
+    return ordered;
+}
+
+function writeOutput(files, outPath) {
+    const outDir = path.dirname(outPath);
+    fs.mkdirSync(outDir, { recursive: true });
+    const out = files.map(({ path: p, text }) => {
+        const cleaned = text
+            .split(/\r?\n/)
+            .filter(l => !l.trim().startsWith('#include'))
+            .join('\n')
+            .trimEnd();
+        return `// File: ${path.basename(p)}\n${cleaned}\n`;
+    }).join('\n');
+    fs.writeFileSync(outPath, out, 'utf8');
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    if (args.length < 1) {
+        console.error('Usage: build.js <entry.hpprgm> [output.hpprgm]');
+        process.exit(1);
+    }
+    const entry = path.resolve(args[0]);
+    const outFile = path.resolve(args[1] || 'combined.hpprgm');
+    const blocks = resolveIncludes(entry, new Set());
+    const seen = new Set();
+    const unique = [];
+    for (const b of blocks) {
+        if (!seen.has(b.path)) {
+            unique.push(b);
+            seen.add(b.path);
+        }
+    }
+    const graph = buildDependencyGraph(unique);
+    const ordered = topoSort(unique, graph);
+    writeOutput(ordered, outFile);
+    console.log(`Built ${outFile}`);
+}
+
+if (require.main === module) {
+    main();
+}


### PR DESCRIPTION
## Summary
- reintroduce a build script to combine HP Prime program files
- expose the bundler via an npm `bundle` script
- document how to use the bundler in the README
- add build task provider so bundler can be triggered with the VSCode build button

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850027858688324ad5d196e31b8d9fd