### PR TITLE
Add BEGIN/END bracket pairing

### DIFF
--- a/client/language-configuration.json
+++ b/client/language-configuration.json
@@ -18,6 +18,14 @@
         [
             "(",
             ")"
+        ],
+        [
+            "BEGIN",
+            "END"
+        ],
+        [
+            "begin",
+            "end"
         ]
     ],
     "autoClosingPairs": [


### PR DESCRIPTION
## Summary
- highlight matching `BEGIN` and `END` keywords by adding them to bracket pairs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850043ba0a083248c23cb1a7cb666c1