### PR TITLE
Add basic test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build-client": "tsc -p client/tsconfig.json",
     "build-server": "tsc -p server/tsconfig.json",
     "watch": "tsc --watch",
-    "bundle": "node scripts/build.js"
+    "bundle": "node scripts/build.js",
+    "test": "npm run build && node --test"
   },
   "repository": {
     "type": "git",

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -1,0 +1,30 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { buildHPProgram } = require('../client/out/client/src/build.js');
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hpprime-test-'));
+}
+
+test('buildHPProgram resolves includes and orders dependencies', () => {
+  const dir = tmpDir();
+  const util = path.join(dir, 'util.hpprgm');
+  const main = path.join(dir, 'main.hpprgm');
+
+  fs.writeFileSync(util, 'EXPORT foo()\nBEGIN\n RETURN 1;\nEND;\n');
+  fs.writeFileSync(main, '#include "util.hpprgm"\nEXPORT MAIN()\nBEGIN\n foo();\nEND;\n');
+
+  const result = buildHPProgram(main);
+
+  assert.ok(result.includes('// ----- util.hpprgm -----'));
+  assert.ok(result.includes('// ----- main.hpprgm -----'));
+  assert.ok(!result.includes('#include'));
+
+  const utilIdx = result.indexOf('util.hpprgm');
+  const mainIdx = result.indexOf('main.hpprgm');
+  assert.ok(utilIdx < mainIdx);
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -1,0 +1,23 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { parseAST } = require('../server/server-dist/shared/parser.js');
+
+test('parseAST extracts includes and functions', () => {
+  const src = [
+    '#include "lib.hpprgm"',
+    'EXPORT foo(a)',
+    'BEGIN',
+    '  RETURN a;',
+    'END;',
+    '',
+    'EXPORT MAIN()',
+    'BEGIN',
+    '  foo(1);',
+    'END;'
+  ].join('\n');
+
+  const { ast, includes } = parseAST(src);
+  assert.deepStrictEqual(includes, ['lib.hpprgm']);
+  const funcs = ast.filter(n => n.type === 'Function').map(n => n.name);
+  assert.deepStrictEqual(funcs, ['foo', 'MAIN']);
+});

--- a/tests/symbolIndex.test.js
+++ b/tests/symbolIndex.test.js
@@ -1,0 +1,32 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { TextDocument } = require('vscode-languageserver-textdocument');
+const { updateSymbolsForDocument, findSymbol, getCompletions, getDefinitionLocation } = require('../server/server-dist/server/symbolIndex.js');
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hpprime-test-'));
+}
+
+test('symbol index provides completions and definitions', () => {
+  const dir = tmpDir();
+  const util = path.join(dir, 'util.hpprgm');
+  const main = path.join(dir, 'main.hpprgm');
+
+  fs.writeFileSync(util, 'EXPORT foo()\nBEGIN\nEND;');
+  fs.writeFileSync(main, '#include "util.hpprgm"\nEXPORT MAIN()\nBEGIN\n foo();\nEND;');
+
+  const mainDoc = TextDocument.create('file://' + main, 'hpprime', 1, fs.readFileSync(main, 'utf8'));
+  updateSymbolsForDocument(mainDoc);
+
+  const completions = getCompletions();
+  assert.ok(completions.some(c => c.label === 'foo'));
+
+  const sym = findSymbol('foo');
+  assert.ok(sym && sym.uri.startsWith('file://'));
+
+  const def = getDefinitionLocation('foo');
+  assert.ok(def && def.uri.endsWith('util.hpprgm'));
+});

--- a/tests/tokenizer.test.js
+++ b/tests/tokenizer.test.js
@@ -1,0 +1,10 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { tokenize, TokenType } = require('../server/server-dist/server/tokenizer.js');
+
+test('tokenize basic program', () => {
+  const tokens = tokenize('EXPORT F()\nBEGIN\nEND;');
+  const hasExport = tokens.some(t => t.type === TokenType.Keyword && t.value.toUpperCase() === 'EXPORT');
+  const hasIdentifier = tokens.some(t => t.type === TokenType.Identifier && t.value === 'F');
+  assert.ok(hasExport && hasIdentifier);
+});


### PR DESCRIPTION
## Summary
- add Node-based tests for parser, bundler, tokenizer and symbol index
- include a test script in package.json to build then run tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685007e3ed008324a1816ce8604c6af1